### PR TITLE
add quotes in add, deleteid and load commands

### DIFF
--- a/helm-mpd.el
+++ b/helm-mpd.el
@@ -376,7 +376,7 @@ To specify a tag, input \"<TAG>PATTERN\"."
   "Delete the selected candidates from the current playlist."
   (helm-mpd-send-command (concat "command_list_begin\n"
                                  (mapconcat (lambda (c)
-                                              (format "deleteid %s"
+                                              (format "deleteid \"%s\""
                                                       (cdr (assq 'Id c))))
                                             (helm-marked-candidates)
                                             "\n")
@@ -394,7 +394,7 @@ To specify a tag, input \"<TAG>PATTERN\"."
   "Add the selected candidates to the current playlist."
   (helm-mpd-send-command (concat "command_list_begin\n"
                                  (mapconcat (lambda (c)
-                                              (format "add %s"
+                                              (format "add \"%s\""
                                                       (cdr (or (assq 'file c)
                                                                (assq 'directory c)))))
                                             (helm-marked-candidates)
@@ -412,7 +412,7 @@ To specify a tag, input \"<TAG>PATTERN\"."
   "Load the selected playlists."
   (helm-mpd-send-command (concat "command_list_begin\n"
                                  (mapconcat (lambda (c)
-                                              (format "load %s"
+                                              (format "load \"%s\""
                                                       (cdr (assq 'playlist c))))
                                             (helm-marked-candidates)
                                             "\n")


### PR DESCRIPTION
Thanks for making this excellent interface to MPD! :)

I had problems adding files with spaces and it turns out that command arguments should be quoted in the musicpd protocol: https://www.musicpd.org/doc/protocol/request_syntax.html

The attached commit fixed the problem in my use case.